### PR TITLE
Fix numerical typos in section headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ SUM(net_worth)
 4202800   
 ```
 
-### Code Along II: `MIN()` and `MAX()`
+### Code Along III: `MIN()` and `MAX()`
 
 The minimum and maximum aggregator functions return the minimum and maximum values from a specified column respectively. 
 
@@ -167,7 +167,7 @@ MIN(net_worth)
 21000   
 ```
 
-### Code Along III: `COUNT()`
+### Code Along IV: `COUNT()`
 
 The count function returns the number of rows that meet a certain condition. 
 


### PR DESCRIPTION
In addition to fixing a couple of typos in the headers, I found a small grammatical error in Line 196. I would suggest changing "a certain criteria" to "a certain criterium", "certain criteria", "a certain requirement", or something similar. This is, admittedly, not a major issue.